### PR TITLE
Avoids the following error message

### DIFF
--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -1435,7 +1435,7 @@ function Base.getproperty(x::PVector, sym::Symbol)
   end
 end
 
-function Base.propertynames(x::PVector, private=false)
+function Base.propertynames(x::PVector, private::Bool=false)
   (fieldnames(typeof(x))...,:owned_values,:ghost_values)
 end
 

--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -2004,7 +2004,7 @@ function Base.getproperty(x::PSparseMatrix, sym::Symbol)
   end
 end
 
-function Base.propertynames(x::PSparseMatrix, private=false)
+function Base.propertynames(x::PSparseMatrix, private::Bool=false)
   (
     fieldnames(typeof(x))...,
     :owned_owned_values,


### PR DESCRIPTION
```
Internal Error: MethodError: propertynames(::PSparseMatrix{Float64, MPIData{SparseArrays.SparseMatrixCSC{Float64, Int64}, 1}, PRange{MPIData{IndexRange, 1}, Exchanger{MPIData{Vector{Int32}, 1}, MPIData{Table{Int32}, 1}}, Nothing}, PRange{MPIData{IndexRange, 1}, Exchanger{MPIData{Vector{Int32}, 1}, MPIData{Table{Int32}, 1}}, Nothing}, Exchanger{MPIData{Vector{Int32}, 1}, MPIData{Table{Int64}, 1}}}, ::Bool) is ambiguous. Candidates:
  propertynames(x, private::Bool) in Base at reflection.jl:1581
  propertynames(x::PSparseMatrix, private) in PartitionedArrays at /home/amartinh/.julia/packages/PartitionedArrays/YgsH7/src/Interfaces.jl:2007
Possible fix, define
  propertynames(::PSparseMatrix, ::Bool)
```