### PR TITLE
added :/ operation between number and Pvector

### DIFF
--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -1777,10 +1777,6 @@ function Base.:*(b::PVector,a::Number)
   a*b
 end
 
-function Base.:/(a::Number,b::PVector)
-  (1/a)*b
-end
-
 function Base.:/(b::PVector,a::Number)
   (1/a)*b
 end

--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -1777,6 +1777,14 @@ function Base.:*(b::PVector,a::Number)
   a*b
 end
 
+function Base.:/(a::Number,b::PVector)
+  (1/a)*b
+end
+
+function Base.:/(b::PVector,a::Number)
+  (1/a)*b
+end
+
 for op in (:+,:-)
   @eval begin
 


### PR DESCRIPTION
Hi @fverdugo, the division operation between `number` and `PVector` is not implemented. I'm not sure if the proposed solution is the most efficient, though.