### PR TITLE
Misc syntax improvements with respect to the usage of backends

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -163,14 +163,14 @@ and including and initializing MPI. Now launching the script with MPI makes the 
 $ mpirun -n 2 julia my-script.jl
 ```
 
-Hence the full MPI code is given in the next code box. Note that we have used the `prun` function that automatically includes and initializes MPI for us.
+Hence the full MPI code is given in the next code box. Note that we have used the `with_backend` function that automatically includes and initializes MPI for us.
 ```julia
 using PartitionedArrays, SparseArrays, IterativeSolvers
 
 np = 2
 backend = MPIBackend()
 
-prun(backend,np) do parts
+with_backend(backend,np) do parts
     # Construct the partitioning
     neighbors, row_partitioning, col_partitioning = map_parts(parts) do part
         if part == 1

--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -30,7 +30,7 @@ function get_part_ids(b::AbstractBackend,nparts::Tuple)
 end
 
 # This can be overwritten to add a finally clause
-function prun(driver::Function,b::AbstractBackend,nparts)
+function with_backend(driver::Function,b::AbstractBackend,nparts)
   part = get_part_ids(b,nparts)
   driver(part)
 end

--- a/src/MPIBackend.jl
+++ b/src/MPIBackend.jl
@@ -1,10 +1,24 @@
 
+# TODO remove this in the future.
+struct MPIBackendDeprecated <: AbstractBackend end
+const mpi = MPIBackendDeprecated()
+function get_part_ids(b::MPIBackendDeprecated,nparts::Integer)
+  @warn "The usage of the constant PartitionedArrays.mpi is deprecated. Use MPIBackend() instead."
+  get_part_ids(MPIBackend(),nparts)
+end
+function get_part_ids(b::MPIBackendDeprecated,nparts::Tuple)
+  @warn "The usage of the constant PartitionedArrays.mpi is deprecated. Use MPIBackend() instead."
+  get_part_ids(MPIBackend(),nparts)
+end
+function prun_debug(driver::Function,b::MPIBackendDeprecated,nparts)
+  @warn "The usage of the constant PartitionedArrays.mpi is deprecated. Use MPIBackend() instead."
+  prun_debug(driver,MPIBackend(),nparts)
+end
+
 get_part_id(comm::MPI.Comm) = MPI.Comm_rank(comm)+1
 num_parts(comm::MPI.Comm) = MPI.Comm_size(comm)
 
 struct MPIBackend <: AbstractBackend end
-
-const mpi = MPIBackend()
 
 function get_part_ids(b::MPIBackend,nparts::Integer)
   comm = MPI.Comm_dup(MPI.COMM_WORLD)

--- a/src/MPIBackend.jl
+++ b/src/MPIBackend.jl
@@ -74,7 +74,7 @@ end
 
 Base.size(a::MPIData) = a.size
 get_part_id(a::MPIData) = get_part_id(a.comm)
-get_backend(a::MPIData) = mpi
+get_backend(a::MPIData) = MPIBackend()
 i_am_main(a::MPIData) = get_part_id(a.comm) == MAIN
 
 function get_part_ids(a::MPIData)

--- a/src/MPIBackend.jl
+++ b/src/MPIBackend.jl
@@ -46,6 +46,7 @@ end
 # Useful to debug an MPI program when executed interactively
 # on the REPL, i.e., with a single MPI task
 function prun_debug(driver::Function,b::MPIBackend,nparts)
+  @warn "Function `prun_debug` is deprecated, use `with_backend` instead."
   if !MPI.Initialized()
     MPI.Init()
   end

--- a/src/MPIBackend.jl
+++ b/src/MPIBackend.jl
@@ -20,7 +20,7 @@ function get_part_ids(b::MPIBackend,nparts::Tuple)
   MPIData(get_part_id(comm),comm,nparts)
 end
 
-function prun(driver::Function,b::MPIBackend,nparts)
+function with_backend(driver::Function,b::MPIBackend,nparts)
   if !MPI.Initialized()
     MPI.Init()
   end

--- a/src/PartitionedArrays.jl
+++ b/src/PartitionedArrays.jl
@@ -9,7 +9,7 @@ import IterativeSolvers
 import Distances
 
 export AbstractBackend
-export prun, prun_debug
+export with_backend, prun_debug
 export AbstractPData
 export SequentialData
 export MPIData

--- a/src/PartitionedArrays.jl
+++ b/src/PartitionedArrays.jl
@@ -9,7 +9,12 @@ import IterativeSolvers
 import Distances
 
 export AbstractBackend
-export with_backend, prun_debug
+export with_backend
+export prun, prun_debug # These ones are deprecated
+function prun(args...;kwargs...)
+  @warn "Function `prun` is deprecated, use `with_backend` instead."
+  with_backend(args...;kwargs...)
+end
 export AbstractPData
 export SequentialData
 export MPIData

--- a/src/SequentialBackend.jl
+++ b/src/SequentialBackend.jl
@@ -14,7 +14,7 @@ function get_part_ids(b::SequentialBackend,nparts::Tuple)
 end
 
 function prun_debug(driver::Function,b::SequentialBackend,nparts)
-  prun(driver,b,nparts)
+  with_backend(driver,b,nparts)
 end
 
 struct SequentialData{T,N} <: AbstractPData{T,N}

--- a/src/SequentialBackend.jl
+++ b/src/SequentialBackend.jl
@@ -14,6 +14,7 @@ function get_part_ids(b::SequentialBackend,nparts::Tuple)
 end
 
 function prun_debug(driver::Function,b::SequentialBackend,nparts)
+  @warn "Function `prun_debug` is deprecated, use `with_backend` instead."
   with_backend(driver,b,nparts)
 end
 

--- a/src/SequentialBackend.jl
+++ b/src/SequentialBackend.jl
@@ -26,7 +26,7 @@ Base.size(a::SequentialData) = size(a.parts)
 
 i_am_main(a::SequentialData) = true
 
-get_backend(a::SequentialData) = sequential
+get_backend(a::SequentialData) = SequentialBackend()
 
 function Base.iterate(a::SequentialData)
   next = map_parts(iterate,a)

--- a/src/SequentialBackend.jl
+++ b/src/SequentialBackend.jl
@@ -1,7 +1,24 @@
 
-struct SequentialBackend <: AbstractBackend end
+# TODO remove this in the future
+struct SequentialBackendDeprecated <: AbstractBackend end
+const sequential = SequentialBackendDeprecated()
+function get_part_ids(b::SequentialBackendDeprecated,nparts::Integer)
+  @warn "The usage of the constant PartitionedArrays.sequential is deprecated. Use SequentialBackend() instead."
+  parts = [ part for part in 1:nparts ]
+  SequentialData(parts)
+end
+function get_part_ids(b::SequentialBackendDeprecated,nparts::Tuple)
+  @warn "The usage of the constant PartitionedArrays.sequential is deprecated. Use SequentialBackend() instead."
+  parts = collect(LinearIndices(nparts))
+  SequentialData(parts)
+end
+function prun_debug(driver::Function,b::SequentialBackendDeprecated,nparts)
+  @warn "The usage of the constant PartitionedArrays.sequential is deprecated. Use SequentialBackend() instead."
+  @warn "Function `prun_debug` is deprecated, use `with_backend` instead."
+  with_backend(driver,b,nparts)
+end
 
-const sequential = SequentialBackend()
+struct SequentialBackend <: AbstractBackend end
 
 function get_part_ids(b::SequentialBackend,nparts::Integer)
   parts = [ part for part in 1:nparts ]

--- a/test/mpi/driver_exception.jl
+++ b/test/mpi/driver_exception.jl
@@ -1,3 +1,3 @@
 include("../test_exception.jl")
 nparts = (2,2,2)
-with_backend(test_exception,mpi,nparts)
+with_backend(test_exception,MPIBackend(),nparts)

--- a/test/mpi/driver_exception.jl
+++ b/test/mpi/driver_exception.jl
@@ -1,3 +1,3 @@
 include("../test_exception.jl")
 nparts = (2,2,2)
-prun(test_exception,mpi,nparts)
+with_backend(test_exception,mpi,nparts)

--- a/test/mpi/driver_fdm.jl
+++ b/test/mpi/driver_fdm.jl
@@ -1,4 +1,4 @@
 include("../test_fdm.jl")
 nparts = (2,2,2)
-prun(test_fdm,mpi,nparts)
+with_backend(test_fdm,mpi,nparts)
 

--- a/test/mpi/driver_fdm.jl
+++ b/test/mpi/driver_fdm.jl
@@ -1,4 +1,4 @@
 include("../test_fdm.jl")
 nparts = (2,2,2)
-with_backend(test_fdm,mpi,nparts)
+with_backend(test_fdm,MPIBackend(),nparts)
 

--- a/test/mpi/driver_fem_sa.jl
+++ b/test/mpi/driver_fem_sa.jl
@@ -1,4 +1,4 @@
 include("../test_fem_sa.jl")
 
 nparts = (2,2)
-prun(test_fem_sa,mpi,nparts)
+with_backend(test_fem_sa,mpi,nparts)

--- a/test/mpi/driver_fem_sa.jl
+++ b/test/mpi/driver_fem_sa.jl
@@ -1,4 +1,4 @@
 include("../test_fem_sa.jl")
 
 nparts = (2,2)
-with_backend(test_fem_sa,mpi,nparts)
+with_backend(test_fem_sa,MPIBackend(),nparts)

--- a/test/mpi/driver_interfaces.jl
+++ b/test/mpi/driver_interfaces.jl
@@ -1,3 +1,3 @@
 include("../test_interfaces.jl")
 nparts = 4
-with_backend(test_interfaces,mpi,nparts)
+with_backend(test_interfaces,MPIBackend(),nparts)

--- a/test/mpi/driver_interfaces.jl
+++ b/test/mpi/driver_interfaces.jl
@@ -1,3 +1,3 @@
 include("../test_interfaces.jl")
 nparts = 4
-prun(test_interfaces,mpi,nparts)
+with_backend(test_interfaces,mpi,nparts)

--- a/test/mpi/driver_mpi_backend.jl
+++ b/test/mpi/driver_mpi_backend.jl
@@ -237,8 +237,8 @@ using MPI
 MPI.Init()
 
 nparts = 4
-main(get_part_ids(mpi,nparts))
+main(get_part_ids(MPIBackend(),nparts))
 
 nparts = (2,2)
-main(get_part_ids(mpi,nparts))
+main(get_part_ids(MPIBackend(),nparts))
 

--- a/test/mpi/driver_p_timers.jl
+++ b/test/mpi/driver_p_timers.jl
@@ -1,3 +1,3 @@
 include("../test_p_timers.jl")
 nparts = 4
-with_backend(test_p_timers,mpi,nparts)
+with_backend(test_p_timers,MPIBackend(),nparts)

--- a/test/mpi/driver_p_timers.jl
+++ b/test/mpi/driver_p_timers.jl
@@ -1,3 +1,3 @@
 include("../test_p_timers.jl")
 nparts = 4
-prun(test_p_timers,mpi,nparts)
+with_backend(test_p_timers,mpi,nparts)

--- a/test/sequential/FDMTests.jl
+++ b/test/sequential/FDMTests.jl
@@ -3,9 +3,9 @@ module FDMTests
 include("../test_fdm.jl")
 
 nparts = (2,2,2)
-prun_debug(test_fdm,sequential,nparts)
+with_backend(test_fdm,sequential,nparts)
 
 nparts = 4
-prun_debug(test_fdm,sequential,nparts)
+with_backend(test_fdm,sequential,nparts)
 
 end # module

--- a/test/sequential/FDMTests.jl
+++ b/test/sequential/FDMTests.jl
@@ -3,9 +3,9 @@ module FDMTests
 include("../test_fdm.jl")
 
 nparts = (2,2,2)
-with_backend(test_fdm,sequential,nparts)
+with_backend(test_fdm,SequentialBackend(),nparts)
 
 nparts = 4
-with_backend(test_fdm,sequential,nparts)
+with_backend(test_fdm,SequentialBackend(),nparts)
 
 end # module

--- a/test/sequential/FEMSATests.jl
+++ b/test/sequential/FEMSATests.jl
@@ -1,8 +1,8 @@
 include("../test_fem_sa.jl")
 
 nparts = (2,2)
-with_backend(test_fem_sa,sequential,nparts)
+with_backend(test_fem_sa,SequentialBackend(),nparts)
 
 nparts = 4
-with_backend(test_fem_sa,sequential,nparts)
+with_backend(test_fem_sa,SequentialBackend(),nparts)
 

--- a/test/sequential/FEMSATests.jl
+++ b/test/sequential/FEMSATests.jl
@@ -1,8 +1,8 @@
 include("../test_fem_sa.jl")
 
 nparts = (2,2)
-prun(test_fem_sa,sequential,nparts)
+with_backend(test_fem_sa,sequential,nparts)
 
 nparts = 4
-prun(test_fem_sa,sequential,nparts)
+with_backend(test_fem_sa,sequential,nparts)
 

--- a/test/sequential/InterfacesTests.jl
+++ b/test/sequential/InterfacesTests.jl
@@ -3,10 +3,10 @@ module InterfacesTests
 include("../test_interfaces.jl")
 
 nparts = 4
-prun(test_interfaces,sequential,nparts)
+with_backend(test_interfaces,sequential,nparts)
 
 nparts = (2,2)
-prun(test_interfaces,sequential,nparts)
+with_backend(test_interfaces,sequential,nparts)
 
 end # module
 

--- a/test/sequential/InterfacesTests.jl
+++ b/test/sequential/InterfacesTests.jl
@@ -3,10 +3,10 @@ module InterfacesTests
 include("../test_interfaces.jl")
 
 nparts = 4
-with_backend(test_interfaces,sequential,nparts)
+with_backend(test_interfaces,SequentialBackend(),nparts)
 
 nparts = (2,2)
-with_backend(test_interfaces,sequential,nparts)
+with_backend(test_interfaces,SequentialBackend(),nparts)
 
 end # module
 

--- a/test/sequential/PTimersTests.jl
+++ b/test/sequential/PTimersTests.jl
@@ -3,6 +3,6 @@ module PTimersTests
 include("../test_p_timers.jl")
 
 nparts = 5
-with_backend(test_p_timers,sequential,nparts)
+with_backend(test_p_timers,SequentialBackend(),nparts)
 
 end # module

--- a/test/sequential/PTimersTests.jl
+++ b/test/sequential/PTimersTests.jl
@@ -3,6 +3,6 @@ module PTimersTests
 include("../test_p_timers.jl")
 
 nparts = 5
-prun(test_p_timers,sequential,nparts)
+with_backend(test_p_timers,sequential,nparts)
 
 end # module

--- a/test/sequential/SequentialBackendTests.jl
+++ b/test/sequential/SequentialBackendTests.jl
@@ -210,9 +210,9 @@ function main(parts)
 end
 
 nparts = 4
-main(get_part_ids(sequential,nparts))
+main(get_part_ids(SequentialBackend(),nparts))
 
 nparts = (2,2)
-main(get_part_ids(sequential,nparts))
+main(get_part_ids(SequentialBackend(),nparts))
 
 end # module


### PR DESCRIPTION
- Do not use constants `sequental` and `mpi` anymore. Use `SequentalBackend()` and `MPIBackend()` instead. Main reason: Having global constants written in lower case letters is not a good idea.
-  prun is renamed to with_backend
- Old syntax is still working, but with deprecation warnings.

Example:

OLD
```julia
prun(mpi,np) do parts
end
```
NEW
```julia
with_backend(MPIBackend(),np) do parts
end
```

cc @amartinhuertas @fredrikekre @termi-official 