### PR TITLE
Remove unused type parameter in method definition

### DIFF
--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -928,7 +928,7 @@ function async_exchange!(
   combine_op,
   values::AbstractPData{<:AbstractVector{Trcv}},
   exchanger::Exchanger,
-  t0::AbstractPData=_empty_tasks(exchanger.parts_rcv)) where {Trcv,Tsnd}
+  t0::AbstractPData=_empty_tasks(exchanger.parts_rcv)) where {Trcv}
 
   async_exchange!(combine_op,values,values,exchanger,t0)
 end


### PR DESCRIPTION
This causes a warning when compiling the package:
```
WARNING: method definition for async_exchange! at C:\Users\olavm\.julia\packages\PartitionedArrays\g9b74\src\Interfaces.jl:857 declares type variable Tsnd but does not use it.
```

To be honest, also `Trcv` looks useless (but at least it's referenced in the method signature).

Spotted in https://github.com/fredrikekre/HYPRE.jl/issues/11#issue-1523729138