### PR TITLE
Bugfix: Executing programs within a subcommunicator of COMM_WORLD

### DIFF
--- a/src/MPIBackend.jl
+++ b/src/MPIBackend.jl
@@ -95,8 +95,10 @@ function with_backend(driver,b::MPIBackend,nparts,args...;kwargs...)
     driver(part,args...;kwargs...)
   else
     try
-       part = get_part_ids(b,nparts)
-       driver(part,args...;kwargs...)
+      part = get_part_ids(b,nparts)
+      if i_am_in(part)
+        driver(part,args...;kwargs...)
+      end
     catch e
       @error "" exception=(e, catch_backtrace())
       if MPI.Initialized() && !MPI.Finalized()

--- a/test/mpi/InterfacesTests.jl
+++ b/test/mpi/InterfacesTests.jl
@@ -2,5 +2,6 @@ module InterfacesTests
 
 include("mpiexec.jl")
 run_mpi_driver(procs=4,file="driver_interfaces.jl")
+run_mpi_driver(procs=6,file="driver_interfaces.jl")
 
 end # module


### PR DESCRIPTION
`with_backend` now works as intended in PR #87 .

When running a program in a subcommunicator, `with_backend` only runs the driver on the subcommunicator (instead of the whole COMM_WORLD). 