### PR TITLE
Reproducing error in test_interfaces

### DIFF
--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -1856,6 +1856,20 @@ end
 function Base.broadcasted(
   f,
   a::Union{PVector,DistributedBroadcasted},
+  b::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}})
+ Base.broadcasted(f,a,Base.materialize(b))
+end
+
+function Base.broadcasted(
+  f,
+  a::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}},
+  b::Union{PVector,DistributedBroadcasted})
+  Base.broadcasted(f,Base.materialize(a),b)
+end
+
+function Base.broadcasted(
+  f,
+  a::Union{PVector,DistributedBroadcasted},
   b::Number)
 
   owned_values = map_parts(a->Base.broadcasted(f,a,b),a.owned_values)

--- a/test/test_interfaces.jl
+++ b/test/test_interfaces.jl
@@ -552,20 +552,24 @@ function test_interfaces(parts)
 
   v  = similar(w,Float64)
   v .= w
+  
   w  = similar(v)
   w .= v
-
+  
   α = 0.2
-  w .=  w .* (1.0/α) .- v .* ((1.0-α)/α)   # DOES NOT FAIL
-  @. w =  w - v                            # DOES NOT FAIL
-  @. w =  w * α                            # DOES NOT FAIL
-  println(@macroexpand @. w =  w * (1.0/α))
-  # The previous line produces on screen:
-  # w .= (*).(w, (/).(1.0, α))
-  @. w =  w * (1.0/α)                      # FAILS! WHY? I guess due to (/).(1.0, α)
-  #@. w =  w * (1.0/α) - v * ((1.0-α)/α)   # FAILS! WHY?
-  @test isa(w,PVector)
-
+  w .=  w .* (1.0/α)
+  @. v =  v * (1.0/α)
+  map_parts(w.values,v.values) do w,v
+    @test w == v
+  end
+  
+  v .= w
+  w .=  (1.0/α) .* w 
+  @. v = (1.0/α) * v 
+  map_parts(w.values,v.values) do w,v
+    @test w == v
+  end
+     
   w .= v .- u
   w .= v .- 1 .- u
   w .= u

--- a/test/test_interfaces.jl
+++ b/test/test_interfaces.jl
@@ -529,6 +529,8 @@ function test_interfaces(parts)
   @test sqeuclidean(w,v) ≈ (norm(w-v))^2
   @test euclidean(w,v) ≈ norm(w-v)
 
+
+  # Broadcast tests
   w = similar(v)
   w = similar(v,Float64)
   w = similar(v,Float64,ids3)
@@ -546,6 +548,22 @@ function test_interfaces(parts)
   w =  v .+ w .- u
   @test isa(w,PVector)
   w =  v .+ 1 .- u
+  @test isa(w,PVector)
+
+  v  = similar(w,Float64)
+  v .= w
+  w  = similar(v)
+  w .= v
+
+  α = 0.2
+  w .=  w .* (1.0/α) .- v .* ((1.0-α)/α)   # DOES NOT FAIL
+  @. w =  w - v                            # DOES NOT FAIL
+  @. w =  w * α                            # DOES NOT FAIL
+  println(@macroexpand @. w =  w * (1.0/α))
+  # The previous line produces on screen:
+  # w .= (*).(w, (/).(1.0, α))
+  @. w =  w * (1.0/α)                      # FAILS! WHY? I guess due to (/).(1.0, α)
+  #@. w =  w * (1.0/α) - v * ((1.0-α)/α)   # FAILS! WHY?
   @test isa(w,PVector)
 
   w .= v .- u


### PR DESCRIPTION
Generated a MWE in `test_interfaces.jl` for the error reported in https://github.com/gridap/GridapDistributed.jl/issues/105

```julia
@. w =  w * (1.0/α) # FAILS!!!
```

fails. 

```julia
w .=  w .* (1.0/α) # DOES NOT FAIL!!!
```

DOES NOT. 

The only difference is that `@. w =  w * (1.0/α)` translates into `w .=  w .* (1.0./α)`

Any ideas of that might be the cause of the error?
