### PR TITLE
Fixing similar() for PSparseMatrix

### DIFF
--- a/src/p_sparse_matrix.jl
+++ b/src/p_sparse_matrix.jl
@@ -168,11 +168,6 @@ function Base.show(io::IO,k::MIME"text/plain",data::PSparseMatrix)
     end
 end
 
-function Base.copy(a::PSparseMatrix)
-    a_matrix_partition = similar(a.matrix_partition)
-    copy!(a_matrix_partition, a.matrix_partition)
-    PSparseMatrix(a_matrix_partition,a.row_partition,a.col_partition)
-end
 
 struct SparseMatrixAssemblyCache
     cache::VectorAssemblyCache

--- a/src/p_sparse_matrix.jl
+++ b/src/p_sparse_matrix.jl
@@ -168,6 +168,12 @@ function Base.show(io::IO,k::MIME"text/plain",data::PSparseMatrix)
     end
 end
 
+function Base.copy(a::PSparseMatrix)
+    a_matrix_partition = similar(a.matrix_partition)
+    copy!(a_matrix_partition, a.matrix_partition)
+    PSparseMatrix(a_matrix_partition,a.row_partition,a.col_partition)
+end
+
 struct SparseMatrixAssemblyCache
     cache::VectorAssemblyCache
 end
@@ -360,7 +366,7 @@ end
 function Base.similar(a::PSparseMatrix,::Type{T},inds::Tuple{<:PRange,<:PRange}) where T
     rows,cols = inds
     row_partition = partition(rows)
-    col_partition = partition(rows)
+    col_partition = partition(cols)
     matrix_partition = map(partition(a),row_partition,col_partition) do values, row_indices, col_indices
         allocate_local_values(values,T,row_indices,col_indices)
     end

--- a/src/p_sparse_matrix.jl
+++ b/src/p_sparse_matrix.jl
@@ -9,12 +9,6 @@ function allocate_local_values(a,::Type{T},indices_rows,indices_cols) where T
     similar(a,T,m,n)
 end
 
-function allocate_local_values(::Type{V},indices_rows,indices_cols) where V
-    m = local_length(indices_rows)
-    n = local_length(indices_cols)
-    similar(V,m,n)
-end
-
 function local_values(values,indices_rows,indices_cols)
     values
 end
@@ -365,16 +359,10 @@ end
 
 function Base.similar(a::PSparseMatrix,::Type{T},inds::Tuple{<:PRange,<:PRange}) where T
     rows,cols = inds
-    matrix_partition = map(partition(a),partition(rows),partition(cols)) do values, row_indices, col_indices
+    row_partition = partition(rows)
+    col_partition = partition(rows)
+    matrix_partition = map(partition(a),row_partition,col_partition) do values, row_indices, col_indices
         allocate_local_values(values,T,row_indices,col_indices)
-    end
-    PSparseMatrix(values,row_partition,col_partition)
-end
-
-function Base.similar(::Type{<:PSparseMatrix{V}},inds::Tuple{<:PRange,<:PRange}) where V
-    rows,cols = inds
-    matrix_partition = map(partition(a),partition(rows),partition(cols)) do values, row_indices, col_indices
-        allocate_local_values(V,row_indices,col_indices)
     end
     PSparseMatrix(matrix_partition,row_partition,col_partition)
 end

--- a/test/p_sparse_matrix_tests.jl
+++ b/test/p_sparse_matrix_tests.jl
@@ -55,11 +55,12 @@ function p_sparse_matrix_tests(distribute)
         @test all( values .== 6 )
     end
 
+    inds = (PRange(A.row_partition),PRange(A.col_partition))
+    A2 = similar(A, eltype(A), inds)
     consistent!(b) |> wait
     map(partition(b)) do values
       @test all( values .== 6 )
     end
-
     LinearAlgebra.fillstored!(A,1.0)
     fill!(x,3.0)
     mul!(b,A,x)

--- a/test/p_sparse_matrix_tests.jl
+++ b/test/p_sparse_matrix_tests.jl
@@ -55,8 +55,9 @@ function p_sparse_matrix_tests(distribute)
         @test all( values .== 6 )
     end
 
-    inds = (PRange(A.row_partition),PRange(A.col_partition))
+    inds = axes(A)
     A2 = similar(A, eltype(A), inds)
+
     consistent!(b) |> wait
     map(partition(b)) do values
       @test all( values .== 6 )


### PR DESCRIPTION
This PR puts order in the Base.similar() overloads for PSparseMatrix

1. Fixes + add tests for one of them.
2. Removes the other. This particular overload does not actually have sufficient info to create a fully-defined instance of a SparseMatrix from the type