### PR TITLE
Improving ExchangeGraph_impl() 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,16 @@
+authors = ["Francesc Verdugo <f.verdugo.rojano@vu.nl> and contributors"]
 name = "PartitionedArrays"
 uuid = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
-authors = ["Francesc Verdugo <f.verdugo.rojano@vu.nl> and contributors"]
 version = "0.3.2"
+
+[compat]
+CircularArrays = "1"
+Distances = "0.10"
+FillArrays = "0.10, 0.11, 0.12, 0.13, 1"
+IterativeSolvers = "0.9"
+MPI = "0.16, 0.17, 0.18, 0.19, 0.20"
+SparseMatricesCSR = "0.6"
+julia = "1.1"
 
 [deps]
 CircularArrays = "7a955b69-7140-5f4e-a0ed-f168c5e2e749"
@@ -15,16 +24,8 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
 
-[compat]
-CircularArrays = "1"
-Distances = "0.10"
-FillArrays = "0.10, 0.11, 0.12, 0.13, 1"
-IterativeSolvers = "0.9"
-MPI = "0.16, 0.17, 0.18, 0.19, 0.20"
-SparseMatricesCSR = "0.6"
-julia = "1.1"
-
 [extras]
+MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/test/fem_example.jl
+++ b/test/fem_example.jl
@@ -323,7 +323,6 @@ function fem_example(distribute)
     dof_partition = map(setup_dofs,space,grid,tentative_dof_partition)
     # Some optimizations when building A
     try
-        PartitionedArrays.DISCOVER_NEIGHBORS_ACTION[] = :error
         cell_partition = uniform_partition(rank,params.parts_per_dir,params.cells_per_dir,ghost_per_dir)
         I_owner = find_owner(tentative_dof_partition,I)
         row_partition = map(union_ghost,tentative_dof_partition,I,I_owner)
@@ -331,9 +330,7 @@ function fem_example(distribute)
         assembly_graph(row_partition;neighbors)
         t = psparse!(I,J,V,row_partition,tentative_dof_partition,discover_rows=false)
         A = fetch(t)
-        PartitionedArrays.DISCOVER_NEIGHBORS_ACTION[] = :allow
     catch e
-        PartitionedArrays.DISCOVER_NEIGHBORS_ACTION[] = :allow
         rethrow(e)
     end
 end

--- a/test/primitives_tests.jl
+++ b/test/primitives_tests.jl
@@ -334,9 +334,4 @@ function primitives_tests(distribute)
    map(parts_snd,parts_snd_2) do parts_snd, parts_snd_2
        @test parts_snd == parts_snd_2
    end
-
-   PartitionedArrays.DISCOVER_NEIGHBORS_ACTION[] = :error
-   @test_throws ErrorException graph2 = ExchangeGraph(parts_rcv)
-   PartitionedArrays.DISCOVER_NEIGHBORS_ACTION[] = :allow
-
 end


### PR DESCRIPTION
1. Moved current implementation of ExchangeGraph_impl()  to debug arrays code
2. Implemented Alg 2 in https://dl.acm.org/doi/10.1145/1837853.1693476 for the ExchangeGraph_impl() associated to mpi arrays
3. Removed the code associated to the warn/error issued when the non-scalable algorithm was invoked