### PR TITLE
Generalizing with_debug() and with_mpi() functions

### DIFF
--- a/src/debug_array.jl
+++ b/src/debug_array.jl
@@ -4,8 +4,8 @@
 
 Call `f(DebugArray)`.
 """
-function with_debug(f,args...;kwargs...)
-    f(DebugArray,args...;kwargs...)
+function with_debug(f)
+    f(DebugArray)
 end
 
 # Auxiliary array type

--- a/src/debug_array.jl
+++ b/src/debug_array.jl
@@ -4,8 +4,8 @@
 
 Call `f(DebugArray)`.
 """
-function with_debug(f)
-    f(DebugArray)
+function with_debug(f,args...;kwargs...)
+    f(DebugArray,args...;kwargs...)
 end
 
 # Auxiliary array type

--- a/src/mpi_array.jl
+++ b/src/mpi_array.jl
@@ -36,7 +36,7 @@ function distribute_with_mpi(a;comm::MPI.Comm=MPI.COMM_WORLD,duplicate_comm=true
 end
 
 """
-    with_mpi(f,args...;comm=MPI.COMM_WORLD,duplicate_comm=true,kwargs...)
+    with_mpi(f;comm=MPI.COMM_WORLD,duplicate_comm=true,kwargs...)
 
 Call `f(a->distribute_with_mpi(a;comm=comm,kwargs...))`
 and abort MPI if there was an error.  This is the safest way of running the function `f` using MPI.
@@ -44,16 +44,16 @@ and abort MPI if there was an error.  This is the safest way of running the func
 !!! note
     This function calls `MPI.Init()` if MPI is not initialized yet.
 """
-function with_mpi(f,args...;comm::MPI.Comm=MPI.COMM_WORLD,duplicate_comm=true,kwargs...)
+function with_mpi(f;comm::MPI.Comm=MPI.COMM_WORLD,duplicate_comm=true,kwargs...)
     if !MPI.Initialized()
         MPI.Init()
     end
     distribute = a -> distribute_with_mpi(a;comm=comm,duplicate_comm=duplicate_comm)
     if MPI.Comm_size(comm) == 1
-        f(distribute,args...;kwargs...)
+        f(distribute)
     else
         try
-            f(distribute,args...;kwargs...)
+            f(distribute)
         catch e
             @error "" exception=(e, catch_backtrace())
             if MPI.Initialized() && !MPI.Finalized()

--- a/src/mpi_array.jl
+++ b/src/mpi_array.jl
@@ -36,19 +36,19 @@ function distribute_with_mpi(a;comm::MPI.Comm=MPI.COMM_WORLD,duplicate_comm=true
 end
 
 """
-    with_mpi(f;comm=MPI.COMM_WORLD,duplicate_comm=true,kwargs...)
+    with_mpi(f;comm=MPI.COMM_WORLD,duplicate_comm=true)
 
-Call `f(a->distribute_with_mpi(a;comm=comm,kwargs...))`
+Call `f(a->distribute_with_mpi(a;comm,duplicate_comm))`
 and abort MPI if there was an error.  This is the safest way of running the function `f` using MPI.
 
 !!! note
     This function calls `MPI.Init()` if MPI is not initialized yet.
 """
-function with_mpi(f;comm::MPI.Comm=MPI.COMM_WORLD,duplicate_comm=true,kwargs...)
+function with_mpi(f;comm::MPI.Comm=MPI.COMM_WORLD,duplicate_comm=true)
     if !MPI.Initialized()
         MPI.Init()
     end
-    distribute = a -> distribute_with_mpi(a;comm=comm,duplicate_comm=duplicate_comm)
+    distribute = a -> distribute_with_mpi(a;comm,duplicate_comm)
     if MPI.Comm_size(comm) == 1
         f(distribute)
     else

--- a/src/mpi_array.jl
+++ b/src/mpi_array.jl
@@ -8,7 +8,7 @@ function ptrs_to_counts(ptrs)
 end
 
 """
-    distribute_with_mpi(a,comm::MPI.Comm=MPI.COMM_WORLD;duplicate_comm=true)
+    distribute_with_mpi(a;comm=MPI.COMM_WORLD,duplicate_comm=true)
 
 Create an [`MPIArray`](@ref) instance by distributing
 the items in the collection `a` over the ranks of the given MPI
@@ -22,7 +22,7 @@ Otherwise, a copy will be done with `MPI.Comm_dup(comm)`.
 !!! note
     This function calls `MPI.Init()` if MPI is not initialized yet.
 """
-function distribute_with_mpi(a,comm::MPI.Comm=MPI.COMM_WORLD;duplicate_comm=true)
+function distribute_with_mpi(a;comm::MPI.Comm=MPI.COMM_WORLD,duplicate_comm=true)
     if !MPI.Initialized()
         MPI.Init()
     end
@@ -36,24 +36,24 @@ function distribute_with_mpi(a,comm::MPI.Comm=MPI.COMM_WORLD;duplicate_comm=true
 end
 
 """
-    with_mpi(f,comm=MPI.COMM_WORLD;kwargs...)
+    with_mpi(f,args...;comm=MPI.COMM_WORLD,duplicate_comm=true,kwargs...)
 
-Call `f(a->distribute_with_mpi(a,comm;kwargs...))`
+Call `f(a->distribute_with_mpi(a;comm=comm,kwargs...))`
 and abort MPI if there was an error.  This is the safest way of running the function `f` using MPI.
 
 !!! note
     This function calls `MPI.Init()` if MPI is not initialized yet.
 """
-function with_mpi(f,comm=MPI.COMM_WORLD;kwargs...)
+function with_mpi(f,args...;comm::MPI.Comm=MPI.COMM_WORLD,duplicate_comm=true,kwargs...)
     if !MPI.Initialized()
         MPI.Init()
     end
-    distribute = a -> distribute_with_mpi(a,comm;kwargs...)
+    distribute = a -> distribute_with_mpi(a;comm=comm,duplicate_comm=duplicate_comm)
     if MPI.Comm_size(comm) == 1
-        f(distribute)
+        f(distribute,args...;kwargs...)
     else
         try
-            f(distribute)
+            f(distribute,args...;kwargs...)
         catch e
             @error "" exception=(e, catch_backtrace())
             if MPI.Initialized() && !MPI.Finalized()
@@ -144,8 +144,8 @@ function Base.setindex!(a::MPIArray,v,i::Int)
     end
     v
 end
-linear_indices(a::MPIArray) = distribute_with_mpi(LinearIndices(a),a.comm,duplicate_comm=false)
-cartesian_indices(a::MPIArray) = distribute_with_mpi(CartesianIndices(a),a.comm,duplicate_comm=false)
+linear_indices(a::MPIArray) = distribute_with_mpi(LinearIndices(a),comm=a.comm,duplicate_comm=false)
+cartesian_indices(a::MPIArray) = distribute_with_mpi(CartesianIndices(a),comm=a.comm,duplicate_comm=false)
 function Base.show(io::IO,k::MIME"text/plain",data::MPIArray)
     header = ""
     if ndims(data) == 1


### PR DESCRIPTION
Redesigning the signatures of with_mpi(f,...) and with_debug(f,...) such that they now allow the user to pass args... and kwargs... to the f function. This is useful, e.g., to pass info about the layout of the process grid from GridapDistributed