### PR TITLE
Bugfix: `Base.similar` for `PSparseMatrix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Function `partition_from_color`.
 
+### Fixed
+
+- Bugfix: `Base.similar` methods for `PSparseMatrix` not working.
+
 ## [0.3.3] - 2023-08-09
 
 ### Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 - Function `partition_from_color`.
+- `Base.copyto!` and `Base.copy!` for `PSparseMatrix`.
 
 ### Fixed
 

--- a/src/p_sparse_matrix.jl
+++ b/src/p_sparse_matrix.jl
@@ -402,7 +402,7 @@ end
 
 function Base.similar(::Type{<:PSparseMatrix{V}},inds::Tuple{<:PRange,<:PRange}) where V
     rows,cols = inds
-    matrix_partition = map(partition(a),partition(rows),partition(cols)) do values, row_indices, col_indices
+    matrix_partition = map(partition(rows),partition(cols)) do row_indices, col_indices
         allocate_local_values(V,row_indices,col_indices)
     end
     PSparseMatrix(matrix_partition,partition(rows),partition(cols))

--- a/src/p_sparse_matrix.jl
+++ b/src/p_sparse_matrix.jl
@@ -397,7 +397,7 @@ function Base.similar(a::PSparseMatrix,::Type{T},inds::Tuple{<:PRange,<:PRange})
     matrix_partition = map(partition(a),partition(rows),partition(cols)) do values, row_indices, col_indices
         allocate_local_values(values,T,row_indices,col_indices)
     end
-    PSparseMatrix(values,row_partition,col_partition)
+    PSparseMatrix(matrix_partition,partition(rows),partition(cols))
 end
 
 function Base.similar(::Type{<:PSparseMatrix{V}},inds::Tuple{<:PRange,<:PRange}) where V
@@ -405,7 +405,7 @@ function Base.similar(::Type{<:PSparseMatrix{V}},inds::Tuple{<:PRange,<:PRange})
     matrix_partition = map(partition(a),partition(rows),partition(cols)) do values, row_indices, col_indices
         allocate_local_values(V,row_indices,col_indices)
     end
-    PSparseMatrix(matrix_partition,row_partition,col_partition)
+    PSparseMatrix(matrix_partition,partition(rows),partition(cols))
 end
 
 function LinearAlgebra.fillstored!(a::PSparseMatrix,v)

--- a/test/p_sparse_matrix_tests.jl
+++ b/test/p_sparse_matrix_tests.jl
@@ -60,6 +60,10 @@ function p_sparse_matrix_tests(distribute)
       @test all( values .== 6 )
     end
 
+    _A = similar(A)
+    _A = similar(A,eltype(A),axes(A))
+    #_A = similar(typeof(A),axes(A)) # This should work, but fails down the line in SparseArrays.jl
+
     LinearAlgebra.fillstored!(A,1.0)
     fill!(x,3.0)
     mul!(b,A,x)

--- a/test/p_sparse_matrix_tests.jl
+++ b/test/p_sparse_matrix_tests.jl
@@ -63,6 +63,7 @@ function p_sparse_matrix_tests(distribute)
     _A = similar(A)
     _A = similar(A,eltype(A),axes(A))
     #_A = similar(typeof(A),axes(A)) # This should work, but fails down the line in SparseArrays.jl
+    copy!(_A,A)
 
     LinearAlgebra.fillstored!(A,1.0)
     fill!(x,3.0)


### PR DESCRIPTION
Hi @fverdugo , could you have a look at this? 

A concern: 

I've commented the test for 
```julia
Base.similar(::Type{<:PSparseMatrix{V}},inds::Tuple{<:PRange,<:PRange}) where V
```
This signature does not work, but it's not our issue. The problem comes from `SparseArrays.jl`, which only provides an [undefined constructor](https://github.com/JuliaSparse/SparseArrays.jl/blob/18b7fcefa18098d2c1752431d1c6fc656b44b888/src/sparsematrix.jl#L55) with signature 
```julia
SparseMatrixCSC{Tv,Ti}(::UndefInitializer, m::Integer, n::Integer) where {Tv, Ti}
```
whereas `Base.similar` calls 
```julia
SparseMatrixCSC{Tv,Ti}(::UndefInitializer, s::Tuple{Integer,Integer}) where {Tv, Ti}
```

I guess we should open an issue in `SparseArrays.jl`, but I've [commented the test](https://github.com/JordiManyer/PartitionedArrays.jl/blob/a353252a84826f7ac2ac2d30ef2cd01256dcb22c/test/p_sparse_matrix_tests.jl#L65) for now. 

Log of the error for convenience: 
```julia
ERROR: LoadError: MethodError: no method matching SparseArrays.SparseMatrixCSC{Float64, Int64}(::UndefInitializer, ::Tuple{Int64, Int64})

Closest candidates are:
  SparseArrays.SparseMatrixCSC{Tv, Ti}(::LinearAlgebra.UniformScaling, ::Tuple{Int64, Int64}) where {Tv, Ti}
   @ SparseArrays ~/bin/julia-1.9.2/share/julia/stdlib/v1.9/SparseArrays/src/sparsematrix.jl:2016
  SparseArrays.SparseMatrixCSC{Tv, Ti}(::UndefInitializer, ::Integer, ::Integer) where {Tv, Ti}
   @ SparseArrays ~/bin/julia-1.9.2/share/julia/stdlib/v1.9/SparseArrays/src/sparsematrix.jl:55

Stacktrace:
  [1] similar(#unused#::Type{SparseArrays.SparseMatrixCSC{Float64, Int64}}, dims::Tuple{Int64, Int64})
    @ Base ./abstractarray.jl:882
  [2] similar(::Type{SparseArrays.SparseMatrixCSC{Float64, Int64}}, ::Int64, ::Int64)
    @ Base ./abstractarray.jl:880
  [3] allocate_local_values(#unused#::Type{SparseArrays.SparseMatrixCSC{Float64, Int64}}, indices_rows::PartitionedArrays.LocalIndicesWithConstantBlockSize{1}, indices_cols::PartitionedArrays.LocalIndicesWithConstantBlockSize{1})
    @ PartitionedArrays ~/Documents/PartitionedArrays.jl/src/p_sparse_matrix.jl:15

```